### PR TITLE
Add productSearch query to find products by name

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,15 +16,17 @@ sleep 4
 docker exec -t -u postgres productcatalog_db_1 \
   psql --command "CREATE DATABASE test_${DB_NAME};"
 
+sleep 1
+
 docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm app \
   yarn run migration:run -c test
 
 EXIT_CODE=$?
 
-docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm app yarn test
-
 if [ ${EXIT_CODE} == 0 ]
 then
+  docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm app yarn test
+
   EXIT_CODE=$?
 fi
 

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,4 +1,10 @@
-import { GraphQLSchema, GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql'
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLNonNull
+} from 'graphql'
 import {
   nodeDefinitions,
   fromGlobalId,
@@ -43,29 +49,29 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
     interfaces: [nodeInterface],
     fields: (): GraphQLFieldReturn => ({
       id: globalIdField(),
-      name: { type: GraphQLString },
+      name: { type: GraphQLNonNull(GraphQLString) },
       description: {
-        type: GraphQLString,
+        type: GraphQLNonNull(GraphQLString),
         description: 'Detailed description of the product.'
       },
       imagePath: {
-        type: GraphQLString,
+        type: GraphQLNonNull(GraphQLString),
         description: 'Path to an image file for the product.'
       },
       attachmentPath: {
-        type: GraphQLString,
+        type: GraphQLNonNull(GraphQLString),
         description: 'Path to an attachment file (usually a PDF) for the product.'
       },
       purchasePrice: {
-        type: GraphQLInt,
+        type: GraphQLNonNull(GraphQLInt),
         description: 'Price at which the store buys the product.'
       },
       salePrice: {
-        type: GraphQLInt,
+        type: GraphQLNonNull(GraphQLInt),
         description: 'Price at which the store sells the product.'
       },
       supplierName: {
-        type: GraphQLString,
+        type: GraphQLNonNull(GraphQLString),
         description: 'Name or RUT of the supplier of the product.'
       }
     })
@@ -83,9 +89,9 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
     interfaces: [nodeInterface],
     fields: (): GraphQLFieldReturn => ({
       id: globalIdField(),
-      name: { type: GraphQLString },
+      name: { type: GraphQLNonNull(GraphQLString) },
       products: {
-        type: productConnectionType,
+        type: GraphQLNonNull(productConnectionType),
         description: 'The products that belong to the category.',
         args: connectionArgs,
         resolve: resolveProducts
@@ -120,15 +126,15 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
     fields: (): GraphQLFieldReturn => ({
       node: nodeField,
       fetchCategories: {
-        type: categoryConnectionType,
+        type: GraphQLNonNull(categoryConnectionType),
         args: connectionArgs,
         resolve: resolveFetchCategories,
       },
       searchProducts: {
-        type: productConnectionType,
+        type: GraphQLNonNull(productConnectionType),
         args: {
           searchTerm: {
-            type: GraphQLString,
+            type: GraphQLNonNull(GraphQLString),
             description: `
               Search term to use to match products in the DB.
               Matches on name only, converting the search and the names

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'graphql-relay'
 import { Connection as DbConnection } from 'typeorm'
 
-import { Category} from '../entity/Category'
+import { Category } from '../entity/Category'
 import { Product } from '../entity/Product'
 
 import type { GraphQLFieldConfigMap } from 'graphql'
@@ -22,9 +22,9 @@ type GraphQLFieldReturn = GraphQLFieldConfigMap<any, any>
 async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
   const entityManager = connection.manager
 
-  const {nodeInterface, nodeField} = nodeDefinitions(
+  const { nodeInterface, nodeField } = nodeDefinitions(
     globalId => {
-      const {type, id} = fromGlobalId(globalId)
+      const { type, id } = fromGlobalId(globalId)
 
       if (type === 'Category') return entityManager.findOne(Category, id)
       if (type === 'Product') return entityManager.findOne(Product, id)
@@ -43,7 +43,7 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
     interfaces: [nodeInterface],
     fields: (): GraphQLFieldReturn => ({
       id: globalIdField(),
-      name: {type: GraphQLString},
+      name: { type: GraphQLString },
       description: {
         type: GraphQLString,
         description: 'Detailed description of the product.'
@@ -83,7 +83,7 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
       id: globalIdField(),
       name: { type: GraphQLString },
       products: {
-        type: connectionDefinitions({nodeType: productType}).connectionType,
+        type: connectionDefinitions({ nodeType: productType }).connectionType,
         description: 'The products that belong to the category.',
         args: connectionArgs,
         resolve: resolveProducts
@@ -92,7 +92,7 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
   })
 
   async function resolveFetchCategories(root, args): Promise<Connection<Category>> {
-    const categories = await entityManager.find(Category, {relations: ['products']})
+    const categories = await entityManager.find(Category, { relations: ['products'] })
     return connectionFromArray(categories, args)
   }
 
@@ -100,12 +100,8 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
     name: 'Query',
     fields: (): GraphQLFieldReturn => ({
       node: nodeField,
-      hello: {
-        type: GraphQLString,
-        resolve: (): string => 'world'
-      },
       fetchCategories: {
-        type: connectionDefinitions({nodeType: categoryType}).connectionType,
+        type: connectionDefinitions({ nodeType: categoryType }).connectionType,
         args: connectionArgs,
         resolve: resolveFetchCategories
       }

--- a/test/graphql/index.spec.ts
+++ b/test/graphql/index.spec.ts
@@ -122,7 +122,7 @@ describe('GraphQL schema', () => {
 
   describe('searchProducts', () => {
     const query = `
-      query($searchTerm: String) {
+      query($searchTerm: String!) {
         searchProducts(searchTerm: $searchTerm) {
           edges {
             node { name }


### PR DESCRIPTION
More-or-less recreates current search functionality in production by using lowercasing to slightly normalise queries & names, then using a `LIKE` query to get product records.