### PR TITLE
Add sending of contact message to GQL API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 DB_NAME=<database name>
 HEROKU_APP=<name of the Heroku app>
 SENDGRID_API_KEY=<API key for using SendGrid>
-ADMIN_EMAIL=<email address of the site admin, principally for receiving notification emails>
-HOSTNAME=<domain on which the site is running>
 
 # Prod env vars
 # DATABASE_URL=<URL for postgres database>
+# ADMIN_EMAIL=<email address of the site admin, principally for receiving notification emails>
+# HOSTNAME=<domain on which the site is running>
+# NODE_ENV=<development, test, or production>

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 DB_NAME=<database name>
 HEROKU_APP=<name of the Heroku app>
+SENDGRID_API_KEY=<API key for using SendGrid>
+ADMIN_EMAIL=<email address of the site admin, principally for receiving notification emails>
+HOSTNAME=<domain on which the site is running>
 
 # Prod env vars
 # DATABASE_URL=<URL for postgres database>

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,6 +9,8 @@ services:
       DB_NAME: ${DB_NAME}
       DB_PASSWORD: postgres
       NODE_ENV: test
+      HOSTNAME: localhost
+      ADMIN_EMAIL: test@test.com
     command: yarn run dev
   db:
     image: postgres:12.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       DB_NAME: ${DB_NAME}
       DB_PASSWORD: postgres
       NODE_ENV: development
+      HOSTNAME: localhost
+      ADMIN_EMAIL: test@test.com
     env_file: .env
     stdin_open: true
     tty: true

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "migration:revert": "yarn run ts-node ./node_modules/typeorm/cli.js migration:revert"
   },
   "devDependencies": {
+    "@sendgrid/helpers": "^7.0.1",
     "@types/faker": "^4.1.11",
     "@types/graphql-relay": "^0.6.0",
     "@types/jest": "^25.2.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typescript-eslint": "^0.0.1-alpha.0"
   },
   "dependencies": {
+    "@sendgrid/mail": "^7.0.1",
     "apollo-server-koa": "^2.12.0",
     "graphql": "^15.0.0",
     "graphql-relay": "^0.6.0",

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,0 +1,42 @@
+import sgMail from "@sendgrid/mail";
+
+import type { SendEmailResponse } from "./types";
+
+type SendOptions = {
+  to: string;
+  from: string;
+  subject: string;
+  text: string;
+};
+
+declare interface Email {
+  send: (sendOptions: SendOptions) => Promise<SendEmailResponse>;
+}
+
+const Email: Email = {
+  send: async (sendOptions: SendOptions): Promise<SendEmailResponse> => {
+    sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+    try {
+      await sgMail.send({
+        ...sendOptions,
+        mailSettings: {
+          sandboxMode: {
+            enable: process.env.NODE_ENV !== "production",
+          },
+        },
+      });
+    } catch (error) {
+      console.error(error);
+
+      const responseBody = error.response.body || { errors: ["Unknown error"] };
+      const errorMessages = JSON.stringify(responseBody.errors);
+
+      return { status: "failure", message: errorMessages };
+    }
+
+    return { status: "success", message: "Email was sent" };
+  },
+};
+
+export default Email;

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -4,6 +4,7 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLNonNull,
+  GraphQLEnumType,
 } from "graphql";
 import {
   nodeDefinitions,
@@ -24,6 +25,10 @@ import type { Connection } from "graphql-relay";
 // graphql package uses 'any' type so we will too
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GraphQLFieldReturn = GraphQLFieldConfigMap<any, any>;
+type SendMessageResponse = {
+  status: string;
+  message: string;
+};
 
 async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
   const entityManager = connection.manager;
@@ -131,6 +136,39 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
     return connectionFromArray(products, args);
   }
 
+  const messageStatusEnum = new GraphQLEnumType({
+    name: "MessageStatus",
+    values: {
+      SUCCESS: { value: "success" },
+      FAILURE: { value: "failure" },
+    },
+  });
+
+  const sendMessageResponseType = new GraphQLObjectType({
+    name: "SendMessageResponse",
+    fields: (): GraphQLFieldReturn => ({
+      status: {
+        type: messageStatusEnum,
+      },
+      message: {
+        type: GraphQLNonNull(GraphQLString),
+      },
+    }),
+  });
+
+  async function resolveSendContactMessage(
+    root,
+    args
+  ): Promise<SendMessageResponse> {
+    const { personalIdNumber, email, message, name, phoneNumber } = args;
+
+    // Send email via SendGrid and save response
+
+    const emailResponse = { status: "success", message: "hooray" };
+
+    return emailResponse;
+  }
+
   const queryType = new GraphQLObjectType({
     name: "Query",
     fields: (): GraphQLFieldReturn => ({
@@ -154,6 +192,32 @@ async function loadSchema(connection: DbConnection): Promise<GraphQLSchema> {
           ...connectionArgs,
         },
         resolve: resolveSearchProducts,
+      },
+      sendContactMessage: {
+        type: GraphQLNonNull(sendMessageResponseType),
+        args: {
+          personalIdNumber: {
+            type: GraphQLNonNull(GraphQLString),
+            description: "The ID number of the sender, typically their RUT.",
+          },
+          email: {
+            type: GraphQLNonNull(GraphQLString),
+            description: "The sender's email address.",
+          },
+          message: {
+            type: GraphQLNonNull(GraphQLString),
+            description: "The message body to be sent.",
+          },
+          name: {
+            type: GraphQLString,
+            description: "The sender's name.",
+          },
+          phoneNumber: {
+            type: GraphQLString,
+            description: "The senders' phone number.",
+          },
+        },
+        resolve: resolveSendContactMessage,
       },
     }),
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { ApolloServer } from "apollo-server-koa";
 import helmet from "koa-helmet";
 
 import loadSchema from "./graphql";
+import Email from "./email";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 createConnection()
@@ -14,7 +15,8 @@ createConnection()
     const router = new Router();
 
     const schema = await loadSchema(connection);
-    const server = new ApolloServer({ schema });
+    const context = { sendEmail: Email.send };
+    const server = new ApolloServer({ schema, context });
     app.use(server.getMiddleware());
 
     router.get("/", async (ctx) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type SendEmailResponse = {
+  status: string;
+  message: string;
+};

--- a/test/email.spec.ts
+++ b/test/email.spec.ts
@@ -1,0 +1,40 @@
+import sgMail from "@sendgrid/mail";
+import Response from "@sendgrid/helpers/classes/response";
+import faker from "faker";
+
+import Email from "../src/email";
+
+jest.mock("@sendgrid/mail");
+const mockedSgMail = sgMail as jest.Mocked<typeof sgMail>;
+
+describe("Email", () => {
+  describe("send", () => {
+    const sendOptions = {
+      to: faker.internet.email(),
+      from: faker.internet.email(),
+      subject: faker.company.bs(),
+      text: faker.lorem.paragraph(),
+    };
+
+    mockedSgMail.send.mockReturnValue(
+      Promise.resolve([new Response(200, {}), {}])
+    );
+
+    it("calls sendgrid's send function", async () => {
+      await Email.send(sendOptions);
+
+      expect(mockedSgMail.send.mock.calls.length).toEqual(1);
+    });
+
+    it("returns a result object", async () => {
+      const response = await Email.send(sendOptions);
+      expect(response).toEqual({
+        status: "success",
+        message: "Email was sent",
+      });
+    });
+
+    // TODO: Test handling of an error response from SendGrid when we have
+    // the time/patience to figure out how to properly mock it.
+  });
+});

--- a/test/graphql/index.spec.ts
+++ b/test/graphql/index.spec.ts
@@ -192,4 +192,47 @@ describe("GraphQL schema", () => {
       });
     });
   });
+
+  describe("sendContactMessage", () => {
+    const query = `
+      query(
+        $personalIdNumber: String!,
+        $email: String!,
+        $message: String!,
+        $name: String,
+        $phoneNumber: String
+      ) {
+        sendContactMessage(
+          personalIdNumber: $personalIdNumber,
+          email: $email,
+          message: $message,
+          name: $name,
+          phoneNumber: $phoneNumber
+        ) {
+          status
+          message
+        }
+      }
+    `;
+
+    it("sends an email", async () => {
+      await graphql(schema, query);
+
+      // Stub SendGrid functionality and expect it to get called
+    });
+
+    it("returns response status info", async () => {
+      const results = await graphql(schema, query, null, null, {
+        personalIdNumber: "13421234",
+        email: "test@test.com",
+        message: "I want more info",
+        name: "Roberto",
+        phoneNumber: "12341234",
+      });
+      console.log(JSON.stringify(results));
+      const messageResponse = results.data.sendContactMessage;
+
+      expect(messageResponse).toEqual({ status: "SUCCESS", message: "hooray" });
+    });
+  });
 });

--- a/test/graphql/index.spec.ts
+++ b/test/graphql/index.spec.ts
@@ -6,10 +6,10 @@ import faker from "faker";
 
 import loadSchema from "../../src/graphql";
 import { Category } from "../../src/entity/Category";
-// import { Product } from '../../src/entity/Product'
+import { Product } from "../../src/entity/Product";
 
 import type { Connection } from "typeorm";
-import { Product } from "../../src/entity/Product";
+import Email from "../../src/email";
 
 type ProductData = {
   category: Category;
@@ -38,8 +38,6 @@ beforeAll(async () => {
 
   const rangeCount = 5;
   const range = Array(rangeCount).fill(null);
-
-  console.log("Seeding database...");
 
   const categories = range.map(() => ({
     name: faker.commerce.productAdjective(),
@@ -70,8 +68,6 @@ beforeAll(async () => {
   );
 
   await connection.manager.save(products);
-
-  console.log("Database seeded!");
 
   schema = await loadSchema(connection);
 });
@@ -215,24 +211,37 @@ describe("GraphQL schema", () => {
       }
     `;
 
-    it("sends an email", async () => {
-      await graphql(schema, query);
+    const mockResponse = { status: "success", message: "hooray" };
+    const mockSend = jest.fn(async () => mockResponse);
+    Email.send = mockSend;
 
-      // Stub SendGrid functionality and expect it to get called
+    const context = { sendEmail: Email.send };
+    const variables = {
+      personalIdNumber: "13421234",
+      emailAddress: "test@test.com",
+      message: "I want more info",
+      name: "Roberto",
+      phoneNumber: "12341234",
+    };
+
+    it("sends an email", async () => {
+      expect.assertions(1);
+
+      await graphql(schema, query, null, context, variables);
+      expect(mockSend.mock.calls.length).toBe(1);
     });
 
     it("returns response status info", async () => {
-      const results = await graphql(schema, query, null, null, {
-        personalIdNumber: "13421234",
-        emailAddress: "test@test.com",
-        message: "I want more info",
-        name: "Roberto",
-        phoneNumber: "12341234",
-      });
-      console.log(JSON.stringify(results));
+      expect.assertions(1);
+
+      const results = await graphql(schema, query, null, context, variables);
+
       const messageResponse = results.data.sendContactMessage;
 
-      expect(messageResponse).toEqual({ status: "SUCCESS", message: "hooray" });
+      expect(messageResponse).toEqual({
+        ...mockResponse,
+        status: mockResponse.status.toUpperCase(),
+      });
     });
   });
 });

--- a/test/graphql/index.spec.ts
+++ b/test/graphql/index.spec.ts
@@ -197,14 +197,14 @@ describe("GraphQL schema", () => {
     const query = `
       query(
         $personalIdNumber: String!,
-        $email: String!,
+        $emailAddress: String!,
         $message: String!,
         $name: String,
         $phoneNumber: String
       ) {
         sendContactMessage(
           personalIdNumber: $personalIdNumber,
-          email: $email,
+          emailAddress: $emailAddress,
           message: $message,
           name: $name,
           phoneNumber: $phoneNumber
@@ -224,7 +224,7 @@ describe("GraphQL schema", () => {
     it("returns response status info", async () => {
       const results = await graphql(schema, query, null, null, {
         personalIdNumber: "13421234",
-        email: "test@test.com",
+        emailAddress: "test@test.com",
         message: "I want more info",
         name: "Roberto",
         phoneNumber: "12341234",

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,30 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
+"@sendgrid/client@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.0.1.tgz#b85389bb214f5dcfdf0fcbd3746713f57ea33250"
+  integrity sha512-HZhDD1bctv5rM0wqAz9LhJC1IL9YHn5jJvxPqiK/3f3WCQjRvraJ1AkqkFFNFd9lPBVLmcrORX04lojwl+5ZaA==
+  dependencies:
+    "@sendgrid/helpers" "^7.0.1"
+    axios "^0.19.2"
+
+"@sendgrid/helpers@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.0.1.tgz#b97debc793ed3f9f56102e12c2a6d2bbbf0ffb78"
+  integrity sha512-i/zsissq1upgdywtuJKysaplJJZC24GdtEKiJC1IRlXvBHzIjH4eU+rqUFO8h+hGji3UMURGgMFuLUXTUYvZ9w==
+  dependencies:
+    chalk "^2.0.1"
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.0.1.tgz#058295972e45ad4d960d77a043cedc0ebe5f856d"
+  integrity sha512-yFkhjrYQvwpdy8eUiDxLLgPp9o5jHQzjJ5qUkgMr2fuPuYSKKqbpPir1PXIHx0ek2VKkTsvj/7Z5UQk6hPZcrQ==
+  dependencies:
+    "@sendgrid/client" "^7.0.1"
+    "@sendgrid/helpers" "^7.0.1"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1141,6 +1165,13 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-jest@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.3.0.tgz#999d0c19e8427f66b796bf9ea233eedf087b957c"
@@ -1382,7 +1413,7 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -1641,6 +1672,12 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+debug@=3.1.0, debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1658,12 +1695,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   dependencies:
     ms "^2.1.1"
-
-debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -2190,6 +2221,13 @@ flat-cache@^2.0.1:
 flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Currently, submission of contact forms are sent as emails to the site admin. I don't know what format these emails have, so I made up a reasonable subject & body.

Mocking external modules in TypeScript is kind of a pain, so I wasn't able to write a working test for SendGrid's error handling, because the correctly-typed error response didn't have the form that SendGrid actually returns, so I just gave up.