### PR TITLE
Add koa-cors to prevent outside access to the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typescript-eslint": "^0.0.1-alpha.0"
   },
   "dependencies": {
+    "@koa/cors": "2",
     "@sendgrid/mail": "^7.0.1",
     "apollo-server-koa": "^2.12.0",
     "graphql": "^15.0.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,6 @@ createConnection(connectionName)
     const schema = await loadSchema(connection);
     const context = { sendEmail: Email.send };
     const server = new ApolloServer({ schema, context });
-    app.use(server.getMiddleware());
 
     router.get("/", async (ctx) => {
       ctx.body = "Hello World!";

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import Router from "koa-router";
 import { createConnection } from "typeorm";
 import { ApolloServer } from "apollo-server-koa";
 import helmet from "koa-helmet";
+import cors from "@koa/cors";
 
 import loadSchema from "./graphql";
 import Email from "./email";
@@ -24,7 +25,11 @@ createConnection(connectionName)
       ctx.body = "Hello World!";
     });
 
-    app.use(helmet()).use(router.routes()).use(router.allowedMethods());
+    app
+      .use(cors())
+      .use(helmet())
+      .use(router.routes())
+      .use(router.allowedMethods());
 
     server.applyMiddleware({ app });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,7 +443,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@koa/cors@^2.2.1":
+"@koa/cors@2", "@koa/cors@^2.2.1":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-2.2.3.tgz#c32a9907acbee1e72fedfb0b9ac840d2e6f9be57"
   dependencies:


### PR DESCRIPTION
Apollo server leaves the GraphQL API open to the whole world
by default, and it's not easy to configure by design per comments
on related issues. So, we'll use koa-cors to restrict access.