### PR TITLE
Add sendQuoteRequest GQL query

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ We deploy automatically to Heroku with every merged PR that passes CI via a GitH
 
 ## Testing
 
-- Run all tests: `./scripts/test`
+- Run all integration tests: `./scripts/integration_tests.sh`
+  - Do not use `yarn run test:integration`, because all integration tests require a test DB, and the bash script takes care of setup and teardown.
+- Run all unit tests: `docker-compose run --rm app yarn run test:unit`
 
 ## Troubleshooting
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  clearMocks: true,
 };

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -2,7 +2,6 @@
 
 DOCKER_COMPOSE_FILE="${1:-docker-compose.yml}"
 
-docker-compose -f ${DOCKER_COMPOSE_FILE} stop
 docker-compose -f ${DOCKER_COMPOSE_FILE} up -d
 
 ./scripts/wait-for-it.sh localhost:3000 -- echo "Server ready"

--- a/src/email.ts
+++ b/src/email.ts
@@ -5,6 +5,7 @@ type SendOptions = {
   from: string;
   subject: string;
   text: string;
+  html?: string;
 };
 
 export type SendEmailResponse = {

--- a/src/graphql/Queries.ts
+++ b/src/graphql/Queries.ts
@@ -97,8 +97,14 @@ class Queries {
           phoneNumber,
         } = args;
 
-        const emailTo = process.env.ADMIN_EMAIL || "";
-        const hostname = process.env.HOSTNAME || "";
+        const { request } = ctx;
+
+        const { ADMIN_EMAIL: emailTo } = process.env;
+
+        const host = (request && request.host) || "productcatalog.com";
+
+        if (!emailTo)
+          throw Error("Missing ADMIN_EMAIL env var to send emails to.");
 
         const emailMessage = `
             Nombre: ${name}
@@ -110,7 +116,7 @@ class Queries {
 
         const emailOptions = {
           to: emailTo,
-          from: `contacto@${hostname}`,
+          from: `contacto@${host}`,
           subject: "Mensaje de Contacto",
           text: emailMessage,
         };

--- a/src/graphql/Queries.ts
+++ b/src/graphql/Queries.ts
@@ -10,6 +10,7 @@ import type { GraphQLFieldConfig } from "graphql";
 
 import type { SendEmailResponse } from "../email";
 import type { TSource, TContext } from "../types";
+import type { CartItem } from "../entity/Cart";
 
 class Queries {
   private types: GQLTypes;
@@ -112,6 +113,116 @@ class Queries {
           from: `contacto@${hostname}`,
           subject: "Mensaje de Contacto",
           text: emailMessage,
+        };
+
+        const response = await ctx.sendEmail(emailOptions);
+
+        return response;
+      },
+    };
+  }
+
+  get sendQuoteRequest(): GraphQLFieldConfig<TSource, TContext> {
+    return {
+      type: GraphQLNonNull(this.types.sendMessageResponseType),
+      args: {
+        personalIdNumber: {
+          type: GraphQLNonNull(GraphQLString),
+          description: "The ID number of the sender, typically their RUT.",
+        },
+        emailAddress: {
+          type: GraphQLNonNull(GraphQLString),
+          description: "The sender's email address.",
+        },
+        message: {
+          type: GraphQLString,
+          description: "The message body to be sent.",
+        },
+        name: {
+          type: GraphQLNonNull(GraphQLString),
+          description: "The sender's name.",
+        },
+        companyName: {
+          type: GraphQLString,
+          description: "The name of the sender's company.",
+        },
+        phoneNumber: {
+          type: GraphQLString,
+          description: "The senders' phone number.",
+        },
+        city: {
+          type: GraphQLString,
+          description: "The sender's home city.",
+        },
+      },
+      resolve: async (root, args, ctx): Promise<SendEmailResponse> => {
+        const {
+          personalIdNumber,
+          emailAddress,
+          message,
+          name,
+          companyName,
+          phoneNumber,
+          city,
+        } = args;
+
+        const {
+          request,
+          session: { cart },
+        } = ctx;
+
+        const { ADMIN_EMAIL: emailTo } = process.env;
+
+        const host = (request && request.host) || "productcatalog.com";
+
+        if (!cart || cart.cartItems.length == 0)
+          return {
+            status: "failure",
+            message: "No hay productos en el carrito para cotizar.",
+          };
+
+        if (!emailTo)
+          throw Error("Missing ADMIN_EMAIL env var to send emails to.");
+
+        const cartItemRows = cart.cartItems
+          .map(
+            (cartItem: CartItem) => `
+              <tr>
+                <td>${cartItem.product.name}</td>
+                <td>${cartItem.quantity}</td>
+                <td>${cartItem.product.salePrice}</td>
+              </tr>
+            `
+          )
+          .join("\n");
+
+        const emailMessage = `
+            Nombre: ${name}
+            RUT: ${personalIdNumber}
+            Email: ${emailAddress}
+            Número de Teléfono: ${phoneNumber}
+            Nombre de Empresa: ${companyName}
+            Ciudad: ${city}
+            Mensaje: ${message}
+
+            <table>
+              <thead>
+                <th>Producto</th>
+                <th>Cantidad</th>
+                <th>Precio Listado</th>
+              </thead>
+              <tbody>
+                ${cartItemRows}
+              </tbody>
+            </table>
+          `;
+
+        const emailOptions = {
+          to: emailTo,
+          from: `cotizacion@${host}`,
+          subject: "Pedida de Cotización",
+          text: emailMessage,
+          html: emailMessage,
         };
 
         const response = await ctx.sendEmail(emailOptions);

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -24,9 +24,12 @@ async function getObjectFromGlobalId(globalId, ctx): Promise<Entity> {
 
 const { nodeInterface, nodeField } = nodeDefinitions(getObjectFromGlobalId);
 const types = new GqlTypes(nodeInterface);
-const { fetchCategories, searchProducts, sendContactMessage } = new Queries(
-  types
-);
+const {
+  fetchCategories,
+  searchProducts,
+  sendContactMessage,
+  sendQuoteRequest,
+} = new Queries(types);
 
 const queryType = new GraphQLObjectType({
   name: "Query",
@@ -35,6 +38,7 @@ const queryType = new GraphQLObjectType({
     fetchCategories,
     searchProducts,
     sendContactMessage,
+    sendQuoteRequest,
   }),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { Context as KoaContext } from "koa";
+import type { EntityManager } from "typeorm";
 
 import type { SendEmail } from "./email";
 
@@ -10,4 +11,5 @@ export type TContext = KoaContext & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   session: any;
   sendEmail: SendEmail;
+  entityManager: EntityManager;
 };

--- a/test/fixtures/factories.ts
+++ b/test/fixtures/factories.ts
@@ -14,26 +14,10 @@ type ProductFactoryOptions = {
   supplierName?: string;
 };
 
-declare interface ProductFactory {
-  buildMany: (
-    count: number,
-    productOptions?: ProductFactoryOptions
-  ) => Array<Product>;
-  build: (productOptions: ProductFactoryOptions) => Product;
-}
-
 type CategoryFactoryOptions = {
   name?: string;
   products?: Array<Product>;
 };
-
-declare interface CategoryFactory {
-  buildMany: (
-    count: number,
-    categoryOptions?: CategoryFactoryOptions
-  ) => Category | Array<Category>;
-  build: (categoryOptions?: CategoryFactoryOptions) => Category;
-}
 
 const newCategory = (categoryOptions: CategoryFactoryOptions): Category => {
   const defaultCategoryAttributes = {
@@ -52,14 +36,17 @@ const newCategory = (categoryOptions: CategoryFactoryOptions): Category => {
   return category;
 };
 
-const CategoryFactory: CategoryFactory = {
-  buildMany: (count, categoryOptions = {}) => {
+const CategoryFactory = {
+  buildMany: (
+    count: number,
+    categoryOptions: CategoryFactoryOptions = {}
+  ): Array<Category> => {
     return Array(count)
       .fill(null)
       .map(() => newCategory(categoryOptions));
   },
 
-  build: (categoryOptions = {}) => {
+  build: (categoryOptions: CategoryFactoryOptions = {}): Category => {
     return newCategory(categoryOptions);
   },
 };
@@ -89,13 +76,16 @@ const newProduct = (productOptions: ProductFactoryOptions): Product => {
   return new Product(productAttributes);
 };
 
-const ProductFactory: ProductFactory = {
-  buildMany: (count, productOptions: ProductFactoryOptions = {}) => {
+const ProductFactory = {
+  buildMany: (
+    count: number,
+    productOptions: ProductFactoryOptions = {}
+  ): Array<Product> => {
     return Array(count)
       .fill(null)
       .map(() => newProduct(productOptions));
   },
-  build: (productOptions: ProductFactoryOptions = {}) => {
+  build: (productOptions: ProductFactoryOptions = {}): Product => {
     return newProduct(productOptions);
   },
 };

--- a/test/integration/graphql/Mutations.spec.ts
+++ b/test/integration/graphql/Mutations.spec.ts
@@ -8,7 +8,6 @@ import faker from "faker";
 import { schema } from "../../../src/graphql";
 import { Category } from "../../../src/entity/Category";
 import { Product } from "../../../src/entity/Product";
-import Email from "../../../src/email";
 import { ProductFactory, CategoryFactory } from "../../fixtures/factories";
 
 // Declaring global variables to be able to make a DB connection
@@ -22,203 +21,35 @@ beforeAll(async () => {
   baseContext = { entityManager: connection.manager };
 
   // Make sure the DB is empty
-  const existingCategories = await connection.manager.find(Category);
-  const categoryCount = existingCategories.length;
+  const categoryCount = await connection
+    .createQueryBuilder(Category, "categories")
+    .getCount();
   assert(categoryCount === 0);
 
-  const recordCount = 5;
+  const recordCount = 2;
 
+  // For now, we don't have mutations that modify DB records, and manager.save
+  // doesn't return attributes set by the DB (e.g. id). So, it's easier
+  // to create a few records here and fetch them with DB queries as needed.
   const categories = CategoryFactory.buildMany(recordCount);
-  await connection.manager.insert(Category, categories);
+  await connection.manager.save(categories);
   const categoryRecords = await connection.manager.find(Category);
 
   const products = categoryRecords.flatMap((category: Category) =>
     ProductFactory.buildMany(recordCount, { category })
   );
-
   await connection.manager.save(products);
 });
 
 afterAll(async (done) => {
-  await connection.dropDatabase();
+  await connection.createQueryBuilder().delete().from(Product).execute();
+  await connection.createQueryBuilder().delete().from(Category).execute();
+
   connection.close();
   done();
 });
 
 describe("GraphQL schema", () => {
-  describe("fetchCategories", () => {
-    const query = `
-      query {
-        fetchCategories {
-          edges {
-            node {
-              name
-              products {
-                edges {
-                  node {
-                    name
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-
-    it("returns category fields", async () => {
-      expect.assertions(2);
-
-      const context = { ...baseContext };
-
-      const results = await graphql(schema, query, null, context);
-      const categories = results.data.fetchCategories.edges.map(
-        (catEdge) => catEdge.node
-      );
-
-      expect(categories).toContainEqual(
-        expect.objectContaining({ name: expect.any(String) })
-      );
-      expect(categories).not.toContainEqual(undefined);
-    });
-
-    it("returns associated products", async () => {
-      expect.assertions(1);
-
-      const context = { ...baseContext };
-
-      const results = await graphql(schema, query, null, context);
-      const categories = results.data.fetchCategories.edges.map(
-        (catEdge) => catEdge.node
-      );
-
-      const products = categories
-        .map((cat) => cat.products.edges.map((prodEdge) => prodEdge.node))
-        .flat(1);
-
-      expect(products).toContainEqual(
-        expect.objectContaining({ name: expect.any(String) })
-      );
-    });
-  });
-
-  describe("searchProducts", () => {
-    const query = `
-      query($searchTerm: String!) {
-        searchProducts(searchTerm: $searchTerm) {
-          edges {
-            node { name }
-          }
-        }
-      }
-    `;
-
-    it("returns any matching products", async () => {
-      expect.assertions(1);
-
-      const context = { ...baseContext };
-
-      // Need to create the product in the `it` function, because `describe`
-      // callbacks can't be async
-      const category = await connection.manager.findOne(Category, 1);
-
-      await connection.manager.insert(
-        Product,
-        ProductFactory.build({
-          category: category,
-          name: "Guantes de Seguridad",
-        })
-      );
-
-      const results = await graphql(schema, query, null, context, {
-        searchTerm: "guantes",
-      });
-      const products = results.data.searchProducts.edges.map(
-        (prodEdge) => prodEdge.node
-      );
-
-      expect(products).toContainEqual(
-        expect.objectContaining({ name: expect.stringMatching(/[gG]uantes/) })
-      );
-    });
-
-    describe("when there are no matching products", () => {
-      it("returns an empty array", async () => {
-        expect.assertions(1);
-
-        const context = { ...baseContext };
-
-        const results = await graphql(schema, query, null, context, {
-          searchTerm: "something that definitely doesn't exist",
-        });
-        const products = results.data.searchProducts.edges.map(
-          (prodEdge) => prodEdge.node
-        );
-
-        expect(products.length).toEqual(0);
-      });
-    });
-  });
-
-  describe("sendContactMessage", () => {
-    const query = `
-      query(
-        $personalIdNumber: String!,
-        $emailAddress: String!,
-        $message: String!,
-        $name: String,
-        $phoneNumber: String
-      ) {
-        sendContactMessage(
-          personalIdNumber: $personalIdNumber,
-          emailAddress: $emailAddress,
-          message: $message,
-          name: $name,
-          phoneNumber: $phoneNumber
-        ) {
-          status
-          message
-        }
-      }
-    `;
-
-    const mockResponse = { status: "success", message: "hooray" };
-    const mockSend = jest.fn(async () => mockResponse);
-    Email.send = mockSend;
-
-    const variables = {
-      personalIdNumber: "13421234",
-      emailAddress: "test@test.com",
-      message: "I want more info",
-      name: "Roberto",
-      phoneNumber: "12341234",
-    };
-
-    it("sends an email", async () => {
-      expect.assertions(1);
-
-      const context = { ...baseContext, sendEmail: Email.send };
-
-      await graphql(schema, query, null, context, variables);
-      expect(mockSend.mock.calls.length).toBe(1);
-    });
-
-    it("returns response status info", async () => {
-      expect.assertions(1);
-
-      const context = { ...baseContext, sendEmail: Email.send };
-
-      const results = await graphql(schema, query, null, context, variables);
-
-      const messageResponse = results.data.sendContactMessage;
-
-      expect(messageResponse).toEqual({
-        ...mockResponse,
-        status: mockResponse.status.toUpperCase(),
-      });
-    });
-  });
-
   describe("addProductToCart", () => {
     const query = `
       mutation($productId: ID!, $quantity: Int!) {
@@ -248,6 +79,8 @@ describe("GraphQL schema", () => {
       const product = await connection.manager.findOne(Product, 1);
       const gqlId = toGlobalId("Product", String(product.id));
 
+      console.log(JSON.stringify(product));
+
       const session = {};
       const context = { ...baseContext, session };
       const variables = {
@@ -256,6 +89,7 @@ describe("GraphQL schema", () => {
       };
 
       const results = await graphql(schema, query, null, context, variables);
+      console.log(JSON.stringify(results));
       const cartItems = results.data.addProductToCart.cart.cartItems.edges.map(
         (ciEdge) => ciEdge.node
       );
@@ -273,6 +107,7 @@ describe("GraphQL schema", () => {
 
       const firstProduct = await connection.manager.findOne(Product, 1);
       const firstGqlId = toGlobalId("Product", String(firstProduct.id));
+
       const secondProduct = await connection.manager.findOne(Product, 2);
       const secondGqlId = toGlobalId("Product", String(secondProduct.id));
 
@@ -331,9 +166,11 @@ describe("GraphQL schema", () => {
     it("removes the given product from the cart", async () => {
       const firstProduct = await connection.manager.findOne(Product, 1);
       const firstQuantity = faker.random.number({ min: 1, max: 10 });
+
       const secondProduct = await connection.manager.findOne(Product, 2);
-      const secondQuantity = faker.random.number({ min: 1, max: 10 });
       const secondProductId = toGlobalId("Product", String(secondProduct.id));
+      const secondQuantity = faker.random.number({ min: 1, max: 10 });
+
       const firstCartItemId = toGlobalId("CartItem", "1");
 
       const session = {
@@ -394,9 +231,11 @@ describe("GraphQL schema", () => {
       const firstGqlId = toGlobalId("Product", String(firstProduct.id));
       const oldFirstQuantity = 3;
       const newFirstQuantity = oldFirstQuantity + 2;
+
       const secondProduct = await connection.manager.findOne(Product, 2);
       const secondGqlId = toGlobalId("Product", String(secondProduct.id));
       const secondQuantity = faker.random.number({ min: 1, max: 10 });
+
       const firstCartItemId = toGlobalId("CartItem", "1");
 
       const session = {

--- a/test/integration/graphql/Queries.spec.ts
+++ b/test/integration/graphql/Queries.spec.ts
@@ -1,0 +1,222 @@
+import assert from "assert";
+
+import { createConnection, Connection } from "typeorm";
+import { graphql } from "graphql";
+
+import { schema } from "../../../src/graphql";
+import { Category } from "../../../src/entity/Category";
+import { Product } from "../../../src/entity/Product";
+import Email from "../../../src/email";
+import { ProductFactory, CategoryFactory } from "../../fixtures/factories";
+
+// Declaring global variables to be able to make a DB connection
+// once instead of inside every 'it' function, because 'describe' functions
+// can't return promises.
+let connection: Connection;
+let baseContext;
+
+beforeAll(async () => {
+  connection = await createConnection("test");
+  baseContext = { entityManager: connection.manager };
+
+  // Make sure the DB is empty
+  const categoryCount = await connection
+    .createQueryBuilder(Category, "categories")
+    .getCount();
+  assert(categoryCount === 0);
+
+  const recordCount = 5;
+
+  const categories = CategoryFactory.buildMany(recordCount);
+  await connection.manager.save(Category, categories);
+  const categoryRecords = await connection.manager.find(Category);
+
+  const products = categoryRecords.flatMap((category: Category) =>
+    ProductFactory.buildMany(recordCount, { category })
+  );
+
+  await connection.manager.save(products);
+});
+
+afterAll(async (done) => {
+  await connection.createQueryBuilder().delete().from(Product).execute();
+  await connection.createQueryBuilder().delete().from(Category).execute();
+
+  connection.close();
+  done();
+});
+
+describe("GraphQL schema", () => {
+  describe("fetchCategories", () => {
+    const query = `
+      query {
+        fetchCategories {
+          edges {
+            node {
+              name
+              products {
+                edges {
+                  node {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    it("returns category fields", async () => {
+      expect.assertions(2);
+
+      const context = { ...baseContext };
+
+      const results = await graphql(schema, query, null, context);
+      const categories = results.data.fetchCategories.edges.map(
+        (catEdge) => catEdge.node
+      );
+
+      expect(categories).toContainEqual(
+        expect.objectContaining({ name: expect.any(String) })
+      );
+      expect(categories).not.toContainEqual(undefined);
+    });
+
+    it("returns associated products", async () => {
+      expect.assertions(1);
+
+      const context = { ...baseContext };
+
+      const results = await graphql(schema, query, null, context);
+      const categories = results.data.fetchCategories.edges.map(
+        (catEdge) => catEdge.node
+      );
+
+      const products = categories
+        .map((cat) => cat.products.edges.map((prodEdge) => prodEdge.node))
+        .flat(1);
+
+      expect(products).toContainEqual(
+        expect.objectContaining({ name: expect.any(String) })
+      );
+    });
+  });
+
+  describe("searchProducts", () => {
+    const query = `
+      query($searchTerm: String!) {
+        searchProducts(searchTerm: $searchTerm) {
+          edges {
+            node { name }
+          }
+        }
+      }
+    `;
+
+    it("returns any matching products", async () => {
+      expect.assertions(1);
+
+      const context = { ...baseContext };
+
+      // Need to create the product in the `it` function, because `describe`
+      // callbacks can't be async
+      const category = await connection.manager.findOne(Category, 1);
+
+      await connection.manager.save(
+        Product,
+        ProductFactory.build({
+          category: category,
+          name: "Guantes de Seguridad",
+        })
+      );
+
+      const results = await graphql(schema, query, null, context, {
+        searchTerm: "guantes",
+      });
+      const products = results.data.searchProducts.edges.map(
+        (prodEdge) => prodEdge.node
+      );
+
+      expect(products).toContainEqual(
+        expect.objectContaining({ name: expect.stringMatching(/[gG]uantes/) })
+      );
+    });
+
+    describe("when there are no matching products", () => {
+      it("returns an empty array", async () => {
+        expect.assertions(1);
+
+        const context = { ...baseContext };
+
+        const results = await graphql(schema, query, null, context, {
+          searchTerm: "something that definitely doesn't exist",
+        });
+        const products = results.data.searchProducts.edges.map(
+          (prodEdge) => prodEdge.node
+        );
+
+        expect(products.length).toEqual(0);
+      });
+    });
+  });
+
+  describe("sendContactMessage", () => {
+    const query = `
+      query(
+        $personalIdNumber: String!,
+        $emailAddress: String!,
+        $message: String!,
+        $name: String,
+        $phoneNumber: String
+      ) {
+        sendContactMessage(
+          personalIdNumber: $personalIdNumber,
+          emailAddress: $emailAddress,
+          message: $message,
+          name: $name,
+          phoneNumber: $phoneNumber
+        ) {
+          status
+          message
+        }
+      }
+    `;
+
+    const mockResponse = { status: "success", message: "hooray" };
+    const mockSend = jest.fn(async () => mockResponse);
+    Email.send = mockSend;
+
+    const variables = {
+      personalIdNumber: "13421234",
+      emailAddress: "test@test.com",
+      message: "I want more info",
+      name: "Roberto",
+      phoneNumber: "12341234",
+    };
+
+    it("sends an email", async () => {
+      expect.assertions(1);
+
+      const context = { ...baseContext, sendEmail: Email.send };
+
+      await graphql(schema, query, null, context, variables);
+      expect(mockSend.mock.calls.length).toBe(1);
+    });
+
+    it("returns response status info", async () => {
+      expect.assertions(1);
+
+      const context = { ...baseContext, sendEmail: Email.send };
+
+      const results = await graphql(schema, query, null, context, variables);
+
+      const messageResponse = results.data.sendContactMessage;
+
+      expect(messageResponse).toEqual({
+        ...mockResponse,
+        status: mockResponse.status.toUpperCase(),
+      });
+    });
+  });
+});

--- a/test/integration/graphql/index.spec.ts
+++ b/test/integration/graphql/index.spec.ts
@@ -11,17 +11,6 @@ import { Product } from "../../../src/entity/Product";
 import Email from "../../../src/email";
 import { ProductFactory, CategoryFactory } from "../../fixtures/factories";
 
-type ProductData = {
-  category: Category;
-  name: string;
-  description: string;
-  imagePath: string;
-  attachmentPath: string;
-  purchasePrice: number;
-  salePrice: number;
-  supplierName: string;
-};
-
 // Declaring global variables to be able to make a DB connection
 // once instead of inside every 'it' function, because 'describe' functions
 // can't return promises.
@@ -38,7 +27,6 @@ beforeAll(async () => {
   assert(categoryCount === 0);
 
   const recordCount = 5;
-  // const range = Array(rangeCount).fill(null);
 
   const categories = CategoryFactory.buildMany(recordCount);
   await connection.manager.insert(Category, categories);


### PR DESCRIPTION
Allows a user to request a quote for the items in their session Cart, which triggers an Email sent to the site admin.

I also had to debug some spec issues brought on by Jest (unbeknownst to me) running test suites in parallel by default. Parallelisation is good, so I just loosened up on DB checks and cleanup, relying on fuzzy queries/matching without worrying so much about specific values.