### PR TITLE
Add authorization for API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ SENDGRID_API_KEY=<API key for using SendGrid>
 # HOSTNAME=<domain on which the site is running>
 # NODE_ENV=<development, test, or production>
 # APP_Key=<reasonably-long string of characters>
+# API_TOKEN=<Token for making authorized calls to the API>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Optional:
 - `docker-compose up` (add `-d` if you want to run it in the background)
 - Open the browser to `localhost:3000`
 
+### GraphQL Playground
+- Navigate to `localhost:3333/graphql`
+- To make make authorized requests to the GraphQL API, you have to add `{"Authorization": "supersecretspicysauce"}` to the HTTP Headers section in the bottom left corner of the page.
+
 ## Deployment
 
 We host the app on Heroku.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,6 +12,7 @@ services:
       HOSTNAME: localhost
       ADMIN_EMAIL: test@test.com
       APP_KEY: supersecretsauce
+      API_TOKEN: supersecretspicysauce
     command: yarn run dev
   db:
     image: postgres:12.2
@@ -24,4 +25,6 @@ services:
       - "3000:3000"
     depends_on:
       - server
+    environment:
+      API_TOKEN: supersecretspicysauce
     command: yarn run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,11 @@ services:
       - ./server:/app
       - productcatalog_server_node_modules:/app/node_modules
     ports:
-      - "3333:3000"
+      - "3333:3333"
     depends_on:
       - db
     environment:
+      PORT: 3333
       DB_HOST: db
       DB_NAME: ${DB_NAME}
       DB_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       HOSTNAME: localhost
       ADMIN_EMAIL: test@test.com
       APP_KEY: supersecretsauce
+      API_TOKEN: supersecretspicysauce
     env_file: .env
     stdin_open: true
     tty: true
@@ -35,6 +36,8 @@ services:
       - productcatalog_client_node_modules:/app/node_modules
     depends_on:
       - server
+    environment:
+      API_TOKEN: supersecretspicysauce
     command: yarn run start
 volumes:
   productcatalog_server_node_modules:

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@sendgrid/helpers": "^7.0.1",
+    "@shopify/jest-koa-mocks": "^2.2.2",
     "@types/faker": "^4.1.11",
     "@types/graphql-relay": "^0.6.0",
     "@types/jest": "^25.2.1",

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -1,0 +1,22 @@
+import type { Context } from "koa";
+
+const isAuthorized = (ctx: Context, appApiToken: string): boolean =>
+  ctx.request.headers.authorization === appApiToken;
+const isApiRequest = (ctx: Context): boolean =>
+  ctx.request.path === "/graphql" && ctx.request.method === "POST";
+
+export function authorizeRequest(appApiToken: string) {
+  return async (
+    ctx: Context,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    next: () => Promise<any>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<Promise<any> | void> => {
+    if (!isApiRequest(ctx) || isAuthorized(ctx, appApiToken)) {
+      return await next();
+    }
+
+    ctx.status = 401;
+    ctx.body = "Unauthorized";
+  };
+}

--- a/server/test/unit/middleware.spec.ts
+++ b/server/test/unit/middleware.spec.ts
@@ -1,0 +1,73 @@
+import { createMockContext } from "@shopify/jest-koa-mocks";
+
+import { authorizeRequest } from "../../src/middleware";
+
+describe("server", () => {
+  describe("authorizeRequest", () => {
+    const requestToken = "lookatmytokenisntitamazing";
+
+    const headers = { Authorization: requestToken };
+    const url = "/graphql";
+    const next = jest.fn(async (): Promise<string> => "next!");
+
+    describe("POST request to /graphql", () => {
+      const ctx = createMockContext({
+        headers,
+        url,
+        method: "POST",
+      });
+
+      describe("when the API tokens match", () => {
+        const appToken = requestToken;
+
+        it("calls next", async () => {
+          expect.assertions(1);
+
+          const middleware = authorizeRequest(appToken);
+          await middleware(ctx, next);
+
+          expect(next.mock.calls.length).toEqual(1);
+        });
+      });
+
+      describe("when the API tokens don't match", () => {
+        const appToken = "thisaintitchief";
+
+        it("returns a 401 response", async () => {
+          expect.assertions(1);
+
+          const middleware = authorizeRequest(appToken);
+          await middleware(ctx, next);
+
+          expect(ctx.status).toEqual(401);
+        });
+
+        it("doesn't call next", async () => {
+          expect.assertions(1);
+
+          const middleware = authorizeRequest(appToken);
+          await middleware(ctx, next);
+
+          expect(next.mock.calls.length).toEqual(0);
+        });
+      });
+    });
+
+    describe("GET request", () => {
+      const ctx = createMockContext({
+        headers,
+        url,
+        method: "GET",
+      });
+
+      it("calls next", async () => {
+        expect.assertions(1);
+
+        const middleware = authorizeRequest("sometoken");
+        await middleware(ctx, next);
+
+        expect(next.mock.calls.length).toEqual(1);
+      });
+    });
+  });
+});

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -522,6 +522,15 @@
     "@sendgrid/client" "^7.1.0"
     "@sendgrid/helpers" "^7.0.1"
 
+"@shopify/jest-koa-mocks@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@shopify/jest-koa-mocks/-/jest-koa-mocks-2.2.2.tgz#c61b369eba48e015f14e488be332e2aa58e97151"
+  integrity sha512-FOBcvqZi/MLVJXpfnG14m/NPSwdJp14PKXDfVInuwYTU+fHSgGTkD7BdOJtW6RswWcxGCaWS0Ep/UKgaf2Ll8Q==
+  dependencies:
+    koa "^2.5.0"
+    node-mocks-http "^1.5.8"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -871,7 +880,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accepts@^1.3.5:
+accepts@^1.3.5, accepts@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   dependencies:
@@ -1812,7 +1821,7 @@ depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
 
-depd@^1.1.2, depd@~1.1.2:
+depd@^1.1.0, depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -2313,7 +2322,7 @@ frameguard@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/frameguard/-/frameguard-3.1.0.tgz#bd1442cca1d67dc346a6751559b6d04502103a22"
 
-fresh@~0.5.2:
+fresh@^0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
@@ -3525,7 +3534,7 @@ koa-session@^6.0.0:
     is-type-of "^1.0.0"
     uuid "^3.3.2"
 
-koa@2.11.0, koa@^2.11.0:
+koa@2.11.0, koa@^2.11.0, koa@^2.5.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/koa/-/koa-2.11.0.tgz#fe5a51c46f566d27632dd5dc8fd5d7dd44f935a4"
   dependencies:
@@ -3658,6 +3667,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+merge-descriptors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3700,6 +3714,11 @@ mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   dependencies:
     mime-db "1.43.0"
+
+mime@^1.3.4:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -3791,6 +3810,21 @@ node-fetch@^2.1.2, node-fetch@^2.2.0:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
+node-mocks-http@^1.5.8:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.8.1.tgz#f149345992618e4d631dfdf77546025d8526b2bb"
+  integrity sha512-qtd9YwXzCTdLfqjP7XSOtFei3TggwnjFIppmYEneQBaDIuknwgJTpItLskC5/pWOpU3lsK5aqdo+5CfIKHkXLg==
+  dependencies:
+    accepts "^1.3.7"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    parseurl "^1.3.3"
+    range-parser "^1.2.0"
+    type-is "^1.6.18"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -4049,7 +4083,7 @@ parse5@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
 
-parseurl@^1.3.2:
+parseurl@^1.3.2, parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
 
@@ -4261,6 +4295,11 @@ qs@^6.5.2:
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
+range-parser@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
 raw-body@^2.3.3:
   version "2.4.1"
@@ -5095,7 +5134,7 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
 
-type-is@^1.6.16:
+type-is@^1.6.16, type-is@^1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   dependencies:


### PR DESCRIPTION
We don't have any sensitive data in the DB right now, so it doesn't matter yet, but GraphQL servers are _really_ open by default, and this provides reasonable security for now.