### PR TITLE
Fix definition of entity associations

### DIFF
--- a/server/src/entity/Category.ts
+++ b/server/src/entity/Category.ts
@@ -27,5 +27,5 @@ export class Category {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @OneToMany((type) => Product, (product) => product.category)
-  public products: Product[];
+  public products: Promise<Product[]>;
 }

--- a/server/src/entity/Product.ts
+++ b/server/src/entity/Product.ts
@@ -23,7 +23,7 @@ type ProductOptions = {
 export class Product {
   constructor(productOptions: ProductOptions) {
     if (productOptions) {
-      this.category = productOptions.category;
+      this.category = Promise.resolve(productOptions.category);
       this.name = productOptions.name;
       this.purchasePrice = productOptions.purchasePrice;
       this.salePrice = productOptions.salePrice;
@@ -68,5 +68,5 @@ export class Product {
     (category) => category.products,
     { onDelete: "SET NULL" }
   )
-  public category: Category;
+  public category: Promise<Category>;
 }

--- a/server/test/fixtures/factories.ts
+++ b/server/test/fixtures/factories.ts
@@ -31,7 +31,7 @@ const newCategory = (categoryOptions: CategoryFactoryOptions): Category => {
   };
 
   const category = new Category(categoryAttributes.name);
-  category.products = categoryAttributes.products;
+  category.products = Promise.resolve(categoryAttributes.products);
 
   return category;
 };


### PR DESCRIPTION
I didn't define lazy-loading associations correctly, leaving out
that they return promises. This caused associations to sometimes
be undefined, especially when loading entities via the node
interface in GQL.