### PR TITLE
Fix newline characters in descriptions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ coverage
 
 # Data stuff
 database/backups
+*.sql

--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,14 @@ coverage
 tmp
 
 # Local stuff
-database/backups
 .vscode
 .DS_STORE
 yarn-error.log
+.vscode
 
 # Secret stuff
 .env
-.vscode
+
+# Data stuff
+database/backups
+*.sql

--- a/client/src/components/Card/Card.tsx
+++ b/client/src/components/Card/Card.tsx
@@ -39,6 +39,10 @@ const CardCta = styled(Button)`
   }
 `;
 
+const ParagraphStyled = styled(Paragraph)`
+  white-space: pre-line
+`;
+
 interface CardProps {
   productId: string;
   name: string;
@@ -82,7 +86,7 @@ const Card: React.FunctionComponent<CardProps> = ({
             <ImageStyled fit="cover" src={linkImage} />
           )}
         </Link>
-        {description && <Paragraph>{description}</Paragraph>}
+        {description && <ParagraphStyled>{description}</ParagraphStyled>}
       </FPCard.Content>
 
       <FPCard.Footer justifyContent="flex-end">


### PR DESCRIPTION
Using `white-space: pre-line` will make `\n` characters cause line breaks in HTML rather than being treated as generic white space.