### PR TITLE
Change Redis URL to use Heroku Redis in production

### DIFF
--- a/server/src/buildCustomAuthRouter.ts
+++ b/server/src/buildCustomAuthRouter.ts
@@ -16,10 +16,10 @@ export const buildCustomAuthRouter = (adminBro, app, connection): Router => {
   });
 
   let store;
-  if (process.env.REDISTOGO_URL) {
+  if (process.env.REDIS_URL) {
     // prod
     store = new RedisStore({
-      client: new Redis(process.env.REDISTOGO_URL),
+      client: new Redis(process.env.REDIS_URL),
     });
   } else {
     // dev


### PR DESCRIPTION
RedisToGo is closing up shop, so we're changing the Redis service
to Heroku's version.