### PR TITLE
Change Redis env var to use new Redis addon

### DIFF
--- a/server/src/buildCustomAuthRouter.ts
+++ b/server/src/buildCustomAuthRouter.ts
@@ -16,10 +16,10 @@ export const buildCustomAuthRouter = (adminBro, app, connection): Router => {
   });
 
   let store;
-  if (process.env.REDIS_URL) {
+  if (process.env.REDISCLOUD_URL) {
     // prod
     store = new RedisStore({
-      client: new Redis(process.env.REDIS_URL),
+      client: new Redis(process.env.REDISCLOUD_URL),
     });
   } else {
     // dev


### PR DESCRIPTION
Heroku are getting rid of the free-tier for their Redis service, and the cheapest paid plan is a bit ridiculous, so we're switching to a different service that still has a free plan.