### PR TITLE
Change enum column to varchar

### DIFF
--- a/server/src/entity/User.ts
+++ b/server/src/entity/User.ts
@@ -44,10 +44,6 @@ export class User extends BaseEntity {
   @Column()
   public encryptedPassword: string;
 
-  @Column({
-    type: "enum",
-    enum: UserRole,
-    default: UserRole.ADMIN,
-  })
+  @Column({ default: UserRole.ADMIN })
   public role: UserRole;
 }

--- a/server/src/migration/1664365082448-ChangeRoleEnumToString.ts
+++ b/server/src/migration/1664365082448-ChangeRoleEnumToString.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeRoleEnumToString1664365082448 implements MigrationInterface {
+  name = "ChangeRoleEnumToString1664365082448";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "role" type VARCHAR`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'admin'`
+    );
+    await queryRunner.query(`DROP TYPE "public"."user_role_enum"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."user_role_enum" AS ENUM('admin', 'editor')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "role" DROP DEFAULT`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "role" TYPE "user_role_enum" USING "role"::"public"."user_role_enum"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'admin'`
+    );
+  }
+}


### PR DESCRIPTION
TypeORM's integration with CockroachDB doesn't support the use of enum columns. This change is to enable migrating from Heroku's Postgres service to CockroachDB.