### PR TITLE
Fix flaky CI browser test

### DIFF
--- a/scripts/browser_tests.sh
+++ b/scripts/browser_tests.sh
@@ -31,7 +31,7 @@ docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm \
 docker-compose -f ${DOCKER_COMPOSE_FILE} up -d
 ./scripts/wait-for-it.sh ${APP_DOMAIN} -- echo "App ready"
 
-sleep 1
+sleep 2
 
 #### RUN TESTS ####
 docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm \


### PR DESCRIPTION
The first browser test run in CI has been failing, but passes on local. Adding an extra second to the sleep seems to be enough to get it passing again.