### PR TITLE
Update node to 16.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # which means we either have to pull images from DockerHub or build them
 # from scratch here. We don't have a DockerHub account set up for this project,
 # so we just build them for now.
-FROM node:14.3.0-buster-slim@sha256:57547465effe6d06ed538dd12ea1ef7f4ed15255822f0b709399c7d2d5f2ff1c AS client
+FROM node:14.3.0-alpine AS client
 
 WORKDIR /app
 
@@ -12,14 +12,12 @@ RUN yarn
 COPY ./client .
 RUN yarn build
 
-FROM node:14.4.0-buster-slim@sha256:c92f4bc74b3233c22d94b264f2912a8935839a008d8c55174cefc5fce9610c7a
+FROM node:14.4.0-alpine
 
 WORKDIR /app
 
-RUN apt-get --no-install-recommends update \
-  && apt-get -y --no-install-recommends install git wget ca-certificates curl \
-  && rm -rf /var/lib/apt/lists/*
-
+RUN apk update \
+  && apk add git wget ca-certificates curl bash
 # Someone getting fancy with the package installs needs git & valid certificates
 # to install via https
 RUN mkdir /usr/local/share/ca-certificates/cacert.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # which means we either have to pull images from DockerHub or build them
 # from scratch here. We don't have a DockerHub account set up for this project,
 # so we just build them for now.
-FROM node:14.3.0-alpine AS client
+FROM node:16.13.1-alpine AS client
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN yarn
 COPY ./client .
 RUN yarn build
 
-FROM node:14.4.0-alpine
+FROM node:16.13.1-alpine
 
 WORKDIR /app
 

--- a/browser_test/Dockerfile
+++ b/browser_test/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node10.16.0-chrome77
+FROM cypress/browsers:node10.16.0-chrome77@sha256:df704dfda7c6e453e78f2f075a9a6a23c428f97dd1b5d09b015adcd05079eca1
 WORKDIR /app
 
 COPY package.json yarn.lock ./

--- a/browser_test/Dockerfile
+++ b/browser_test/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node10.16.0-chrome77@sha256:df704dfda7c6e453e78f2f075a9a6a23c428f97dd1b5d09b015adcd05079eca1
+FROM cypress/browsers:node10.16.0-chrome77
 WORKDIR /app
 
 COPY package.json yarn.lock ./

--- a/browser_test/cypress.admin.json
+++ b/browser_test/cypress.admin.json
@@ -2,5 +2,8 @@
   "baseUrl": "http://localhost:3333",
   "video": false,
   "viewportHeight": 2000,
-  "specPattern": "cypress/integration/admin/**/*.spec.{js,ts}"
+  "specPattern": "cypress/integration/admin/**/*.spec.{js,ts}",
+  "retries": {
+    "runMode": 2
+  }
 }

--- a/browser_test/cypress.catalog.json
+++ b/browser_test/cypress.catalog.json
@@ -2,5 +2,8 @@
   "baseUrl": "http://localhost:3000",
   "video": false,
   "viewportHeight": 2000,
-  "specPattern": "cypress/integration/catalog/**/*.spec.{js,ts}"
+  "specPattern": "cypress/integration/catalog/**/*.spec.{js,ts}",
+  "retries": {
+    "runMode": 2
+  }
 }

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.3.0-alpine
+FROM node:16.13.1-alpine
 
 WORKDIR /app
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,9 +1,4 @@
-# Specifying the sha is to guarantee that CI will not try to rebuild from the
-# source image (i.e. node:13.5), which apparently CIs are bad at avoiding on
-# their own.
-# Using buster-slim instead of alpine, because there's an open issue
-# about flow not working on alpine, and the response is *shrug*
-FROM node:14.3.0-buster-slim@sha256:57547465effe6d06ed538dd12ea1ef7f4ed15255822f0b709399c7d2d5f2ff1c
+FROM node:14.3.0-alpine
 
 WORKDIR /app
 

--- a/scripts/browser_tests.sh
+++ b/scripts/browser_tests.sh
@@ -31,7 +31,7 @@ docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm \
 docker-compose -f ${DOCKER_COMPOSE_FILE} up -d
 ./scripts/wait-for-it.sh "http://localhost:3000" -- echo "App ready"
 
-sleep 4
+sleep 5
 
 EXIT_CODE=0
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,14 +1,7 @@
-# Specifying the sha is to guarantee that CI will not try to rebuild from the
-# source image (i.e. node:13.5), which apparently CIs are bad at avoiding on
-# their own.
-# Using buster-slim instead of alpine, because there's an open issue
-# about flow not working on alpine, and the response is *shrug*
-FROM node:15.10.0-buster-slim@sha256:a52f5f98b3cad961896857e33f3e5078bb05d3805844af53b773d7d7e159ed04
+FROM node:15.10.0-alpine
 
-RUN apt-get --no-install-recommends update \
-  && apt-get -y --no-install-recommends install git wget ca-certificates curl \
-  && rm -rf /var/lib/apt/lists/*
-
+RUN apk update \
+  && apk add git wget ca-certificates curl bash
 # Someone getting fancy with the package installs needs git & valid certificates
 # to install via https
 RUN mkdir /usr/local/share/ca-certificates/cacert.org

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.10.0-alpine
+FROM node:16.13.1-alpine
 
 RUN apk update \
   && apk add git wget ca-certificates curl bash


### PR DESCRIPTION
16.x is the latest version available in AWS Lambda, so it seems
like a good version to stick to while we work on migrating to a
serverless architecture.

Also, changed to `alpine`, since we haven't used Flow for awhile,
and that was the reason for avoiding `alpine`.