### PR TITLE
Fix use of findOne when fetching object via global ID

### DIFF
--- a/browser_test/cypress/e2e/catalog/productpage.spec.js
+++ b/browser_test/cypress/e2e/catalog/productpage.spec.js
@@ -1,0 +1,13 @@
+describe("Product page", function(){
+  describe("When a product item is selected", () => {
+    it("loads the product item", () => {
+      cy.visit("/", { headers: { Connection: "Keep-Alive" }, responseTimeout: 31000 });
+      cy.findByRole("main").within(()=> {
+        cy.get('a').eq(1).click();
+      })
+
+      cy.findAllByRole("link", { name: "ver producto" }).first().click();
+      cy.findByRole("button", { name: "Agregar a cotización" });
+    });
+  })
+});

--- a/scripts/set_local_db_to_prod.sh
+++ b/scripts/set_local_db_to_prod.sh
@@ -28,7 +28,9 @@ docker-compose up -d db
 # Not ideal, but wait-for-it was listening for the port to be ready, but that
 # wasn't enough time for the DB to be ready to accept commands,
 # so we're sleeping instead
-sleep 4
+sleep 10
 
+docker exec -i productcatalog_db_1 \
+  cockroach sql --execute "CREATE DATABASE IF NOT EXISTS ${DB_NAME};" --insecure
 docker exec -i productcatalog_db_1 \
   cockroach sql --file ${DB_PATH} --insecure

--- a/server/src/graphql/index.ts
+++ b/server/src/graphql/index.ts
@@ -16,8 +16,10 @@ type Entity = Category | Product;
 async function getObjectFromGlobalId(globalId, ctx): Promise<Entity> {
   const { type, id } = fromGlobalId(globalId);
 
-  if (type === "Category") return await ctx.entityManager.findOne(Category, id);
-  if (type === "Product") return await ctx.entityManager.findOne(Product, id);
+  if (type === "Category")
+    return await ctx.entityManager.findOneBy(Category, { id });
+  if (type === "Product")
+    return await ctx.entityManager.findOneBy(Product, { id });
 }
 
 const { nodeInterface, nodeField } = nodeDefinitions(getObjectFromGlobalId);


### PR DESCRIPTION
I missed this implementation of the old TypeORM query interface
when updating that package, and we didn't have any test coverage
for node-based queries, so nothing broke on the way to prod.
So, I added a quick regression test to avoid this in the future.