### PR TITLE
Add AdminJS inline scripts to safelist for security policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ database/backups
 
 # adminBro stuff
 server/.adminbro
+server/.adminjs


### PR DESCRIPTION
Helmet was blocking some inline scripts loaded by AdminJS, because
they violate its default Content-Security-Policy of 'self'.
Adding the hashes for the specific inline scripts that are loaded
seems like the safest way to add them, although it will break
again if the maintainers ever change said inline scripts.